### PR TITLE
ci: precisamos usar a versão específica

### DIFF
--- a/.github/workflows/check-link.yml
+++ b/.github/workflows/check-link.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   check-link:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - name: Project checkout

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   analyse:
     name: Analyse
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/continuous_delivery.yml
+++ b/.github/workflows/continuous_delivery.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   lint:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - name: Project checkout
@@ -21,7 +21,7 @@ jobs:
 
   commit-lint:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -37,7 +37,7 @@ jobs:
 
   test-api:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       matrix:
@@ -60,7 +60,7 @@ jobs:
   release:
     needs: [lint, commit-lint, test-api]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - name: Project checkout

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   lint:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - name: Project checkout
@@ -21,7 +21,7 @@ jobs:
 
   commit-lint:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -37,7 +37,7 @@ jobs:
 
   test-api:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       matrix:

--- a/.github/workflows/mutation-test.yml
+++ b/.github/workflows/mutation-test.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test-mutation:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - name: Project checkout


### PR DESCRIPTION
## Description

As versões dos builds utilizados no ci não é específica e isso retira do pipeline a possibilidade dele ser previsivel. O comportamento do pipeline precisa ser o mesmo sempre. 

Como está hoje, quando a Github mudar o ubuntu-latest de 18 para 20, seus pipelines vão mudar de comportamento sem quer você tenha controle sobre isso.

### How can the user experience this change?

Não se aplica

### Documentation

Não se aplica

## PR Tasks

Não se aplica
